### PR TITLE
Add gradient clipping to prevent silent training divergence

### DIFF
--- a/train.py
+++ b/train.py
@@ -816,6 +816,7 @@ FINAL_LR_FRAC = 0.0
 DEPTH = 8
 DEVICE_BATCH_SIZE = 16
 EVAL_BATCH_SIZE = 8
+GRAD_CLIP_MAX_NORM = 1.0
 
 
 def build_model_config(depth, vocab_size, runtime, use_activation_checkpointing=None):
@@ -1139,6 +1140,8 @@ def _run_training_once(runtime, tokenizer, config, device_batch_size, smoke_test
             if group["kind"] == "muon":
                 group["momentum"] = muon_momentum
                 group["weight_decay"] = muon_weight_decay
+        if GRAD_CLIP_MAX_NORM > 0:
+            torch.nn.utils.clip_grad_norm_(model.parameters(), GRAD_CLIP_MAX_NORM)
         optimizer.step()
         model.zero_grad(set_to_none=True)
 


### PR DESCRIPTION
## Summary
- Adds `GRAD_CLIP_MAX_NORM = 1.0` constant alongside other training hyperparameters
- Clips gradients via `torch.nn.utils.clip_grad_norm_()` before `optimizer.step()` in the main training loop
- Guarded by `if GRAD_CLIP_MAX_NORM > 0` so the agent can disable it by setting to 0

## Test plan
- [ ] Run `uv run train.py --smoke-test` to verify no regression
- [ ] Run a full training cycle and confirm loss doesn't explode
- [ ] Verify gradient clipping doesn't degrade normal training convergence

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)