### PR TITLE
Add discarded.md for cross-session experiment memory

### DIFF
--- a/discarded.md
+++ b/discarded.md
@@ -1,0 +1,14 @@
+# Discarded Experiments
+
+This file records experiments that were tried and discarded. Read this at the start of every session to avoid re-discovering known dead ends.
+
+## Format
+
+Each entry should include:
+- **What was tried**: brief description of the change
+- **Result**: val_bpb and memory_gb
+- **Why discarded**: what went wrong or why it wasn't worth keeping
+
+## Entries
+
+(none yet - entries will be added as experiments are run and discarded)

--- a/program.md
+++ b/program.md
@@ -12,6 +12,7 @@ To set up a new experiment, work with the user to:
    - `README.md` — repository context.
    - `prepare.py` — fixed constants, data prep, tokenizer, dataloader, evaluation. Do not modify.
    - `train.py` — the file you modify. Model architecture, optimizer, training loop.
+   - `discarded.md` — history of failed experiments. **Read this first** to avoid re-trying known dead ends.
 4. **Verify data exists**: Check that `~/.cache/autoresearch/` contains data shards and a tokenizer. If not, tell the human to run `uv run prepare.py`.
 5. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
 6. **Confirm and go**: Confirm setup looks good.
@@ -101,7 +102,7 @@ LOOP FOREVER:
 6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
 7. Record the results in the tsv
 8. If val_bpb improved (lower), you "advance" the branch, keeping the git commit
-9. If val_bpb is equal or worse, you git reset back to where you started
+9. If val_bpb is equal or worse, you git reset back to where you started. **Also append the experiment to `discarded.md`** with what you tried, the result, and why it failed — so you (or a future session) never re-tries it.
 
 The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind but you should probably do this very very sparingly (if ever).
 


### PR DESCRIPTION
## Summary
- Creates `discarded.md` to record failed experiments (what was tried, result, why discarded)
- Updates `program.md` setup section to read `discarded.md` at session start
- Updates experiment loop to append discarded experiments so future sessions avoid known dead ends

## Test plan
- [ ] Verify `discarded.md` is read by the agent at session start
- [ ] Run experiment loop and confirm discarded experiments are appended
- [ ] Start a new session and verify agent avoids re-trying recorded failures

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)